### PR TITLE
Use `vercel-dev-runtime`

### DIFF
--- a/.vercelignore
+++ b/.vercelignore
@@ -1,6 +1,5 @@
 /node_modules
 /README.md
-/src
 /dist
 /test
 /.*

--- a/src/index.ts
+++ b/src/index.ts
@@ -124,6 +124,7 @@ export async function build({
 	}
 
 	const sourceFiles = new Set<string>();
+	sourceFiles.add(entrypoint);
 
 	// Patch the `.graph` files to use file paths beginning with `/var/task`
 	// to hot-fix a Deno issue (https://github.com/denoland/deno/issues/6080).

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 	AnalyzeOptions,
 	BuildOptions,
 	Env,
+  FileFsRef,
 	StartDevServerOptions,
 	StartDevServerResult,
 	createLambda,
@@ -42,6 +43,9 @@ interface BuildInfo {
 	program: Program;
 	version: string;
 }
+
+fs.chmodSync(join(__dirname, 'build.sh'), 0o755);
+fs.chmodSync(join(__dirname, 'bootstrap'), 0o755);
 
 export const version = 3;
 
@@ -221,11 +225,20 @@ export async function build({
 		}
 	}
 
+  const outputFiles = {
+      ...(await glob('.deno/**/*', workPath)),
+      ...(await glob('api/**/*', workPath)),
+      '.runtime.ts': await FileFsRef.fromFsPath({ fsPath: join(workPath, '.runtime.ts') }),
+      bootstrap: await FileFsRef.fromFsPath({ fsPath: join(workPath, 'bootstrap') })
+    }
+
+    console.log(outputFiles);
 	const output = await createLambda({
-		files: await glob('**', workPath),
+		files: outputFiles,
 		handler: entrypoint,
 		runtime: 'provided',
 	});
+  console.log(output);
 
 	return { output };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,7 +239,7 @@ export async function build({
 	};
 
 	console.log('Detected source files:');
-	for (const filename of sourceFiles) {
+	for (const filename of Array.from(sourceFiles).sort()) {
 		console.log(` - ${filename}`);
 		outputFiles[filename] = await FileFsRef.fromFsPath({
 			fsPath: join(workPath, filename),

--- a/src/index.ts
+++ b/src/index.ts
@@ -238,7 +238,9 @@ export async function build({
 		...(await glob('.deno/**/*', workPath)),
 	};
 
+	console.log('Detected source files:');
 	for (const filename of sourceFiles) {
+		console.log(` - ${filename}`);
 		outputFiles[filename] = await FileFsRef.fromFsPath({
 			fsPath: join(workPath, filename),
 		});

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "public": true,
-  "functions": {
-    "api/**/*.[jt]s": { "runtime": "vercel-deno@0.3.1" }
-  }
+  "builds": [
+    { "src": "api/**/*.{j,t}s", "use": "https://files-17tuarrcz.vercel.app/vercel-dev-runtime-v0.0.0.tgz" }
+  ]
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,6 +1,6 @@
 {
   "public": true,
-  "builds": [
-    { "src": "api/**/*.{j,t}s", "use": "https://files-17tuarrcz.vercel.app/vercel-dev-runtime-v0.0.0.tgz" }
-  ]
+  "functions": {
+    "api/**/*.[jt]s": { "runtime": "vercel-dev-runtime@0.0.1" }
+  }
 }


### PR DESCRIPTION
This also optimizes the output files in the Lambda zip to only include the relevant source files used by the entrypoint.