### PR TITLE
Fallback to writing port to a tmp file when '/dev/fd/3' is not accessible

### DIFF
--- a/src/bootstrap
+++ b/src/bootstrap
@@ -4,7 +4,7 @@ cd "$LAMBDA_TASK_ROOT"
 export DENO_DIR="$LAMBDA_TASK_ROOT/.deno"
 export PATH="$DENO_DIR/bin:$PATH"
 export NO_COLOR=1
-export HOME="$LAMBDA_TASK_ROOT"
+export HOME="$(eval echo "~")"
 exec deno run \
 	--allow-env \
 	--allow-net \

--- a/src/dev-server.ts
+++ b/src/dev-server.ts
@@ -28,11 +28,11 @@ if (isNetAddr(s.listener.addr)) {
 		Deno.writeAllSync(portFd, portBytes);
 		Deno.close(portFd.rid);
 	} catch (err) {
-		console.log(err);
+		// This fallback is necessary for Windows
+		// See: https://github.com/denoland/deno/issues/6305
 		const portFile = Deno.env.get('VERCEL_DEV_PORT_FILE');
 		if (portFile) {
 			await Deno.writeFile(portFile, portBytes);
-			console.log('wrote', port, 'to', portFile);
 		}
 	}
 }

--- a/src/dev-server.ts
+++ b/src/dev-server.ts
@@ -17,13 +17,12 @@ if (typeof handler !== 'function') {
 // Spawn HTTP server on ephemeral port
 const s = serve({ port: 0 });
 
-// Write the port number to FD 3
 if (isNetAddr(s.listener.addr)) {
 	const { port } = s.listener.addr;
 	const portBytes = new TextEncoder().encode(String(port));
 
 	try {
-		// Open FD 3, which is where the port number needs to be written
+		// Write the port number to FD 3
 		const portFd = Deno.openSync('/dev/fd/3', { read: false, write: true });
 		Deno.writeAllSync(portFd, portBytes);
 		Deno.close(portFd.rid);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import yn from 'yn';
 import { join } from 'path';
+import { tmpdir } from 'os';
 import { spawn } from 'child_process';
 import { Readable } from 'stream';
 import once from '@tootallnate/once';
@@ -290,10 +291,16 @@ export async function startDevServer(
 ): Promise<StartDevServerResult> {
 	const { entrypoint, workPath, meta = {} } = opts;
 
+	const portFile = join(
+		tmpdir(),
+		`vercel-deno-port-${Math.random().toString(32).substring(2)}`
+	);
+
 	const env: typeof process.env = {
 		...process.env,
 		...meta.env,
 		VERCEL_DEV_ENTRYPOINT: join(workPath, entrypoint),
+		VERCEL_DEV_PORT_FILE: portFile,
 	};
 
 	const args: string[] = [
@@ -322,19 +329,55 @@ export async function startDevServer(
 			resolve({ port: Number(d) });
 		});
 	});
+	const onPortFile = waitForPortFile(portFile);
 	const onExit = once.spread<[number, string | null]>(child, 'exit');
-	const result = await Promise.race([onPort, onExit]);
+	const result = await Promise.race([onPort, onPortFile, onExit]);
 	onExit.cancel();
+	onPortFile.cancel();
 
 	if (isPortInfo(result)) {
 		return {
 			port: result.port,
 			pid: child.pid,
 		};
-	} else {
+	} else if (Array.isArray(result)) {
 		// Got "exit" event from child process
 		throw new Error(
 			`Failed to start dev server for "${entrypoint}" (code=${result[0]}, signal=${result[1]})`
 		);
+	} else {
+		throw new Error('Unexpected error');
+	}
+}
+
+export interface CancelablePromise<T> extends Promise<T> {
+	cancel: () => void;
+}
+
+function waitForPortFile(portFile: string) {
+	const opts = { portFile, canceled: false };
+	const promise = waitForPortFile_(
+		opts
+	) as CancelablePromise<PortInfo | void>;
+	promise.cancel = () => {
+		opts.canceled = true;
+	};
+	return promise;
+}
+
+async function waitForPortFile_(opts: {
+	portFile: string;
+	canceled: boolean;
+}): Promise<PortInfo | void> {
+	while (!opts.canceled) {
+		await new Promise((resolve) => setTimeout(resolve, 100));
+		try {
+			const port = Number(await readFile(opts.portFile, 'ascii'));
+			return { port };
+		} catch (err) {
+			if (err.code !== 'ENOENT') {
+				throw err;
+			}
+		}
 	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,7 @@ import {
 	shouldServe,
 } from '@vercel/build-utils';
 
-const { stat, readdir, readFile, writeFile } = fs.promises;
+const { stat, readdir, readFile, writeFile, unlink } = fs.promises;
 
 const DEFAULT_DENO_VERSION = 'v1.1.2';
 
@@ -373,6 +373,9 @@ async function waitForPortFile_(opts: {
 		await new Promise((resolve) => setTimeout(resolve, 100));
 		try {
 			const port = Number(await readFile(opts.portFile, 'ascii'));
+			unlink(opts.portFile).catch(err => {
+				console.error('Could not delete port file: %j', opts.portFile);
+			});
 			return { port };
 		} catch (err) {
 			if (err.code !== 'ENOENT') {


### PR DESCRIPTION
This is for Windows compatibility with the `vercel dev` command (and also #6).