### PR TITLE
Set `output` buffer size in the constructor

### DIFF
--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -50,8 +50,7 @@ async function processEvents(): Promise<void> {
 
 			const data = JSON.parse(event.body);
 			const input = new Deno.Buffer(base64.toUint8Array(data.body || ''));
-			const output = new Deno.Buffer();
-			output.grow(1049000);
+			const output = new Deno.Buffer(new Uint8Array(6000000)); // 6 MB
 
 			const req = new ServerRequest();
 			// req.conn

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -54,7 +54,7 @@ async function processEvents(): Promise<void> {
 
 			const req = new ServerRequest();
 			// req.conn
-			req.r = new BufReader(input);
+			req.r = new BufReader(input, input.length);
 			req.method = data.method;
 			req.url = data.path;
 			req.proto = 'HTTP/1.1';
@@ -80,7 +80,7 @@ async function processEvents(): Promise<void> {
 				throw responseError;
 			}
 
-			const bufr = new BufReader(output);
+			const bufr = new BufReader(output, output.length);
 			const tp = new TextProtoReader(bufr);
 			const firstLine = await tp.readLine(); // e.g. "HTTP/1.1 200 OK"
 			if (firstLine === null) throw new Deno.errors.UnexpectedEof();


### PR DESCRIPTION
As shown here: https://github.com/TooTallNate/vercel-deno/issues/3#issuecomment-651524501