### PR TITLE
Don't error if `DENO_TSCONFIG` env var is not provided

### DIFF
--- a/src/bootstrap
+++ b/src/bootstrap
@@ -9,7 +9,7 @@ if [ -n "${DENO_UNSTABLE-}" ]; then
 fi
 
 tsconfig_flag=
-if [ -n "${DENO_TSCONFIG}" ]; then
+if [ -n "${DENO_TSCONFIG-}" ]; then
 	tsconfig_flag="--config ${DENO_TSCONFIG}"
 	unset DENO_TSCONFIG;
 fi

--- a/src/build.sh
+++ b/src/build.sh
@@ -10,7 +10,7 @@ if [ -n "${DENO_UNSTABLE-}" ]; then
 fi
 
 tsconfig_flag=
-if [ -n "${DENO_TSCONFIG}" ]; then
+if [ -n "${DENO_TSCONFIG-}" ]; then
 	echo "Using tsconfig: ${DENO_TSCONFIG}"
 	tsconfig_flag="-c ${DENO_TSCONFIG}"
 	unset DENO_TSCONFIG


### PR DESCRIPTION
Fixes #29.