### PR TITLE
Ensure values are a string before invoking `startsWith()`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -179,7 +179,7 @@ export async function build({
 		const graph: Graph = JSON.parse(await readFile(file, 'utf8'));
 		for (let i = 0; i < graph.deps.length; i++) {
 			const dep = graph.deps[i];
-			if (dep.startsWith(workPathUri)) {
+			if (typeof dep === 'string' && dep.startsWith(workPathUri)) {
 				const relative = dep.substring(workPathUri.length + 1);
 				const updated = `file:///var/task/${relative}`;
 				graph.deps[i] = updated;
@@ -204,7 +204,7 @@ export async function build({
 		} = buildInfo.program;
 
 		for (const filename of Object.keys(fileInfos)) {
-			if (filename.startsWith(workPathUri)) {
+			if (typeof filename === 'string' && filename.startsWith(workPathUri)) {
 				const relative = filename.substring(workPathUri.length + 1);
 				const updated = `file:///var/task/${relative}`;
 				fileInfos[updated] = fileInfos[filename];
@@ -217,7 +217,7 @@ export async function build({
 		for (const [filename, refs] of Object.entries(referencedMap)) {
 			for (let i = 0; i < refs.length; i++) {
 				const ref = refs[i];
-				if (ref.startsWith(workPathUri)) {
+				if (typeof ref === 'string' && ref.startsWith(workPathUri)) {
 					const relative = ref.substring(workPathUri.length + 1);
 					const updated = `file:///var/task/${relative}`;
 					refs[i] = updated;
@@ -226,7 +226,7 @@ export async function build({
 				}
 			}
 
-			if (filename.startsWith(workPathUri)) {
+			if (typeof filename === 'string' && filename.startsWith(workPathUri)) {
 				const relative = filename.substring(workPathUri.length + 1);
 				const updated = `file:///var/task/${relative}`;
 				referencedMap[updated] = refs;
@@ -239,7 +239,7 @@ export async function build({
 		for (const [filename, refs] of Object.entries(exportedModulesMap)) {
 			for (let i = 0; i < refs.length; i++) {
 				const ref = refs[i];
-				if (ref.startsWith(workPathUri)) {
+				if (typeof ref === 'string' && ref.startsWith(workPathUri)) {
 					const relative = ref.substring(workPathUri.length + 1);
 					const updated = `file:///var/task/${relative}`;
 					refs[i] = updated;
@@ -248,7 +248,7 @@ export async function build({
 				}
 			}
 
-			if (filename.startsWith(workPathUri)) {
+			if (typeof filename === 'string' && filename.startsWith(workPathUri)) {
 				const relative = filename.substring(workPathUri.length + 1);
 				const updated = `file:///var/task/${relative}`;
 				exportedModulesMap[updated] = refs;
@@ -260,7 +260,7 @@ export async function build({
 
 		for (let i = 0; i < semanticDiagnosticsPerFile.length; i++) {
 			const ref = semanticDiagnosticsPerFile[i];
-			if (ref.startsWith(workPathUri)) {
+			if (typeof ref === 'string' && ref.startsWith(workPathUri)) {
 				const relative = ref.substring(workPathUri.length + 1);
 				const updated = `file:///var/task/${relative}`;
 				semanticDiagnosticsPerFile[i] = updated;


### PR DESCRIPTION
Fixes #34.

For posterity, the case that was investigated to fix this had
a `.buildinfo` file that had a "semanticDiagnosticsPerFile" array that
contained strings as well as array objects, like so:

```
  "https://deno.land/std@0.66.0/http/server.ts",
  "https://deno.land/std@0.66.0/io/bufio.ts",
  "https://deno.land/std@0.66.0/textproto/mod.ts",
  "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/deno/tree.ts",
  [
    "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/deno/wasm.ts",
    [
      {
        "file": "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/deno/wasm.ts",
        "start": 80,
        "length": 17,
        "code": 7016,
        "category": 1,
        "messageText": "Could not find a declaration file for module '../wasm/wasm.js'. 'https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/wasm/wasm.js' implicitly has an 'any' type."
      }
    ]
  ],
  "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/mod.ts",
  [
    "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/runtime/mod.ts",
    [
      {
        "file": "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/runtime/mod.ts",
        "start": 17,
        "length": 14,
        "code": 7016,
        "category": 1,
        "messageText": "Could not find a declaration file for module './runtime.js'. 'https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/runtime/runtime.js' implicitly has an 'any' type."
      },
      {
        "file": "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/runtime/mod.ts",
        "start": 55,
        "length": 33,
        "code": 7016,
        "category": 1,
        "messageText": "Could not find a declaration file for module 'https://dev.jspm.io/@babel/core'. 'https://dev.jspm.io/@babel/core' implicitly has an 'any' type."
      },
      {
        "file": "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/runtime/mod.ts",
        "start": 117,
        "length": 39,
        "code": 7016,
        "category": 1,
        "messageText": "Could not find a declaration file for module 'https://dev.jspm.io/@babel/preset-env'. 'https://dev.jspm.io/@babel/preset-env' implicitly has an 'any' type."
      },
      {
        "file": "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/runtime/mod.ts",
        "start": 190,
        "length": 58,
        "code": 7016,
        "category": 1,
        "messageText": "Could not find a declaration file for module 'https://dev.jspm.io/@babel/plugin-syntax-top-level-await'. 'https://dev.jspm.io/@babel/plugin-syntax-top-level-await' implicitly has an 'any' type."
      }
    ]
  ],
  "https://e4qp7sg572biez6tjyvlteqqf3jjgohzocjca6fgfbt5t4h2iekq.arweave.net/JyD_yN3-goJn004quZIQLtKTOPlwkiB4pihn2fD6QRU/runtime/rules.ts",
  "https://iigk45i7o35wcqut6db5ji5nuwoj2nhlbqvk2jqrlhewcix6b7ja.arweave.net/QgyudR92-2FCk_DD1KOtpZydNOsMKq0mEVnJYSL-D9I/_util/assert.ts",
  "https://iigk45i7o35wcqut6db5ji5nuwoj2nhlbqvk2jqrlhewcix6b7ja.arweave.net/QgyudR92-2FCk_DD1KOtpZydNOsMKq0mEVnJYSL-D9I/path/_constants.ts",
  "https://iigk45i7o35wcqut6db5ji5nuwoj2nhlbqvk2jqrlhewcix6b7ja.arweave.net/QgyudR92-2FCk_DD1KOtpZydNOsMKq0mEVnJYSL-D9I/path/_globrex.ts",
  "https://iigk45i7o35wcqut6db5ji5nuwoj2nhlbqvk2jqrlhewcix6b7ja.arweave.net/QgyudR92-2FCk_DD1KOtpZydNOsMKq0mEVnJYSL-D9I/path/_interface.ts",
```