### PR TITLE
docs(config): clarify version format

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,8 @@ export default async (req: ServerRequest) => {
 
 There are also a few flags that can be used that are specific to `vercel-deno`:
 
- * `--version` - Specify a specific version of Deno to use.
+ * `--version` - Specify a specific version of Deno to use. (A version is
+ any valid Deno [release tag](https://github.com/denoland/deno/releases) — e.g. `v1.2.3`)
  * `--include-files` - Glob pattern of static files to include within the Serverless Function. Can be specified more than once.
 
 ## Development


### PR DESCRIPTION
From peeking at the source:

https://github.com/TooTallNate/vercel-deno/blob/f4d56565b15c1adc1729612360c9bfb9d12e11dd/src/index.ts#L161-L163

it looks like the runtime prefixes any argument provided to `--version` with a `"v"` unless it already starts with one

https://github.com/TooTallNate/vercel-deno/blob/f4d56565b15c1adc1729612360c9bfb9d12e11dd/src/build.sh#L15

then uses this value as the release tag when installing Deno.

This PR adds documentation guidance for what is a valid version format.