### PR TITLE
Support native HTTP request API

### DIFF
--- a/api/hello.ts
+++ b/api/hello.ts
@@ -1,5 +1,1 @@
-import { ServerRequest } from 'https://deno.land/std@0.105.0/http/server.ts';
-
-export default async (req: ServerRequest) => {
-	req.respond({ body: `Hello, from Deno v${Deno.version.deno}!` });
-};
+export default () => new Request(`Hello, from Deno v${Deno.version.deno}!`);

--- a/api/hello.ts
+++ b/api/hello.ts
@@ -1,1 +1,1 @@
-export default () => new Request(`Hello, from Deno v${Deno.version.deno}!`);
+export default () => new Response(`Hello, from Deno v${Deno.version.deno}!`);


### PR DESCRIPTION
Both the legacy "std" API and the new native HTTP API are supported, so no breaking changes involved.

Closes #75.